### PR TITLE
[1.x] fix: Don't call state hooks by default when opening the preview modal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^9.5",
         "spatie/invade": "^1.1",
-        "spatie/laravel-ray": "^1.26"
+        "spatie/laravel-ray": "^1.26",
+        "symfony/polyfill-php82": "^1.28"
     },
     "autoload": {
         "psr-4": {

--- a/src/Pages/Concerns/HasPreviewModal.php
+++ b/src/Pages/Concerns/HasPreviewModal.php
@@ -10,6 +10,8 @@ trait HasPreviewModal
 {
     protected array $previewModalData = [];
 
+    protected bool $shouldCallHooksBeforePreview = false;
+
     protected function getPreviewModalUrl(): ?string
     {
         return null;
@@ -46,7 +48,7 @@ trait HasPreviewModal
     /** @internal */
     protected function preparePreviewModalData(): array
     {
-        $data = $this->form->getState();
+        $data = $this->form->getState($this->shouldCallHooksBeforePreview);
         $record = null;
 
         if (method_exists($this, 'mutateFormDataBeforeCreate')) {


### PR DESCRIPTION
backport of https://github.com/pboivin/filament-peek/pull/114